### PR TITLE
use the latest pypy

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,5 +2,5 @@ ansible_ssh_user: core
 ansible_python_dir: /opt/python
 ansible_python_interpreter: "{{ ansible_python_dir }}/bin/python"
 
-python_version: "3.5"
-pypy_version: "6.0.0"
+python_version: "3.6"
+pypy_version: "7.3.1"

--- a/files/install_python.sh
+++ b/files/install_python.sh
@@ -10,14 +10,14 @@ mkdir -p "$PYTHON_DIR"
 cd "$PYTHON_DIR"
 
 
-pypyFile="pypy$PYTHON_VERSION-$PYPY_VERSION-linux_x86_64-portable"
+pypyFile="pypy$PYTHON_VERSION-v$PYPY_VERSION-linux64"
 tarFile="$PYTHON_DIR/$pypyFile.tar.bz2"
 
 if [[ -e "$tarFile" ]]; then
   tar -xjf "$tarFile"
   rm -rf "$tarFile"
 else
-  curl -L "https://bitbucket.org/squeaky/portable-pypy/downloads/$pypyFile.tar.bz2" | tar -xjf -
+  curl -L "https://bitbucket.org/pypy/pypy/downloads/$pypyFile.tar.bz2" | tar -xjf -
 fi
 
 mv -n "$pypyFile" pypy

--- a/files/install_python.sh
+++ b/files/install_python.sh
@@ -27,7 +27,7 @@ mkdir -p "$PYTHON_DIR/bin/"
 
 cat > "$PYTHON_DIR/bin/python" <<EOF
 #!/bin/bash
-LD_LIBRARY_PATH=$PYTHON_DIR/pypy/lib:$LD_LIBRARY_PATH exec $PYTHON_DIR/pypy/bin/pypy "\$@"
+LD_LIBRARY_PATH=$PYTHON_DIR/pypy/lib:$LD_LIBRARY_PATH exec $PYTHON_DIR/pypy/bin/pypy3 "\$@"
 EOF
 
 chmod +x "$PYTHON_DIR/bin/python"


### PR DESCRIPTION
Current version of pypy was compiled on an older Linux and linked with `libcrypt.so.1` which does not exist on `Fedora CoreOS 32.20200629.3.0`
```
[root@ip-10-10-8-158 core]# /opt/python/bin/python
/opt/python/pypy/bin/pypy: error while loading shared libraries: libcrypt.so.1: cannot open shared object file: No such file or directory
[root@ip-10-10-8-158 core]# ldd /opt/python/pypy/bin/pypy
	linux-vdso.so.1 (0x00007fffc7f5d000)
	libpypy3-c.so => /opt/python/pypy/bin/libpypy3-c.so (0x00007fa0db55a000)
	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007fa0db532000)
	libc.so.6 => /lib64/libc.so.6 (0x00007fa0db368000)
	libutil.so.1 => /lib64/libutil.so.1 (0x00007fa0db363000)
	libdl.so.2 => /lib64/libdl.so.2 (0x00007fa0db35c000)
	libbz2.so.1 => /lib64/libbz2.so.1 (0x00007fa0db349000)
	libexpat.so.1 => /opt/python/pypy/bin/../lib/libexpat.so.1 (0x00007fa0db112000)
	libm.so.6 => /lib64/libm.so.6 (0x00007fa0dafcc000)
	libz.so.1 => /lib64/libz.so.1 (0x00007fa0dafb2000)
	librt.so.1 => /lib64/librt.so.1 (0x00007fa0dafa7000)
	libcrypt.so.1 => not found
	libffi.so.6 => /opt/python/pypy/bin/../lib/libffi.so.6 (0x00007fa0dad9a000)
	libncursesw.so.6 => /opt/python/pypy/bin/../lib/libncursesw.so.6 (0x00007fa0dab58000)
	libtinfow.so.6 => /opt/python/pypy/bin/../lib/libtinfow.so.6 (0x00007fa0da91a000)
	libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007fa0da8ff000)
	/lib64/ld-linux-x86-64.so.2 (0x00007fa0df12f000)
[root@ip-10-10-8-158 core]# ls -al /lib64/libcrypt.so.*
lrwxrwxrwx. 2 root root     17 Jul 10 18:02 /lib64/libcrypt.so.2 -> libcrypt.so.2.0.0
-rwxr-xr-x. 2 root root 206176 Jan  1  1970 /lib64/libcrypt.so.2.0.0
```
Upgrading to pypy v7.3.1 fixes the issue.

Also, we no longer need to use [a portable fork of pypy](https://github.com/squeaky-pl/portable-pypy#portable-pypy-distribution-for-linux). The portability has been [incorporated in the upstream](https://www.pypy.org/download.html#linux-binaries-and-common-distributions) after v7.3.0.

